### PR TITLE
Make xhr.getAllResponseHeaders match the specification

### DIFF
--- a/lib/XMLHttpRequest/index.js
+++ b/lib/XMLHttpRequest/index.js
@@ -218,7 +218,15 @@ XMLHttpRequest.prototype.getAllResponseHeaders = function() {
     return '';
   }
 
-  return this.responseHeaders;
+  var headers = '';
+
+  for (var responseHeaderName in this.responseHeaders) {
+    if (this.responseHeaders.hasOwnProperty(responseHeaderName)) {
+      headers += responseHeaderName + ': ' + this.responseHeaders[responseHeaderName] + '\r\n';
+    }
+  }
+
+  return headers;
 };
 
 // now onto fauxJax's specific API

--- a/test/XMLHttpRequest/getAllResponseHeaders.js
+++ b/test/XMLHttpRequest/getAllResponseHeaders.js
@@ -2,6 +2,24 @@ var test = require('tape');
 
 var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
 
+function parseHeaders(headers) {
+  var parsedHeaders = {};
+  var pairs = headers.trim().split('\n');
+  var i;
+  var split;
+  var key;
+  var value;
+
+  for (i = 0; i < pairs.length; i++) {
+    split = pairs[i].split(':');
+    key = split.shift().trim();
+    value = split.join(':').trim();
+    parsedHeaders[key] = value;
+  }
+
+  return parsedHeaders;
+}
+
 test('xhr.getAllResponseHeaders() sends empty string when no headers', function(t) {
   var xhr = new XMLHttpRequest();
   t.equal('', xhr.getAllResponseHeaders(), 'we get an empty string');
@@ -14,6 +32,6 @@ test('xhr.getAllResponseHeaders() sends all response headers when present', func
   xhr.open('GET', '/');
   xhr.send();
   xhr.respond(200, headers);
-  t.deepEqual(xhr.getAllResponseHeaders(), headers, 'we get all the headers');
+  t.deepEqual(parseHeaders(xhr.getAllResponseHeaders()), headers, 'we get all the headers');
   t.end();
 });


### PR DESCRIPTION
> The getAllResponseHeaders() method must return response's header list,
> in list order, as a single byte sequence with each header separated by
> a 0x0D 0x0A byte pair, and each name and value of a header separated
> by a 0x3A 0x20 byte pair.