### PR TITLE
faux-jax now supports node.js http

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
-node_js:
-  - "0.10"
 install: npm install
-script: npm run test-ci
+script: npm run $COMMAND
 branches:
   only:
     - master
@@ -10,3 +8,15 @@ env:
   global:
     - SAUCE_USERNAME=os-algolia-faux-jax
     - SAUCE_ACCESS_KEY=60276788-fd33-42b9-bfbe-9180e63c7c64
+matrix:
+  include:
+    - node_js: "0.10"
+      env: COMMAND=test-ci-browser
+    - node_js: "0.10"
+      env: COMMAND=test-node
+    - node_js: "0.12"
+      env: COMMAND=test-node
+    - node_js: "iojs"
+      env: COMMAND=test-node
+    - node_js: "0.10"
+      env: COMMAND=lint

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+# UNRELEASED
+
+  * BREAKING CHANGE: faux-jax is now asyncrhonous by default, there's no more `.requests` property on the `fauxJax` object
+    Now you need to: fauxJax.on('request', function(err, request) {})
+    This was done while adding the Node.js compatibility and also because asynchronous requests (XHRS, Node.js http) ARE A-S-Y-N-C-H-R-O-N-O-U-S
+  * FEATURE: Node.js compatibility, you can now intercept both on the browser and the server
+
 # 3.0.1 (2015-03-10)
 
   * upgrade lodash to 3.5.0

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,102 @@
+var EventEmitter = require('events').EventEmitter;
+var inherits = require('util').inherits;
+
+var XMLHttpRequestMock = require('./lib/XMLHttpRequest/');
+var XDomainRequestMock = require('./lib/XDomainRequest/');
+var native = require('./lib/native');
+var support = require('./lib/support');
+
+function FauxJax() {
+  this._installed = false;
+}
+
+inherits(FauxJax, EventEmitter);
+
+FauxJax.prototype.install = function() {
+  if (this._installed) {
+    this.emit('error', new Error('faux-jax: Cannot call `install()` twice. Did you forgot to call `restore()`?'));
+    return;
+  }
+
+  this._installed = true;
+
+  // only modify the writable state of XMLHttpRequest in old ies when installing
+  // it will be done only once
+  require('./lib/make-native-implementations-writable')();
+
+  if (this.support.xhr) {
+    global.XMLHttpRequest = FakeXHR;
+  }
+
+  if (this.support.xdr) {
+    global.XDomainRequest = FakeXDR;
+  }
+};
+
+FauxJax.prototype.restore = function() {
+  if (!this._installed) {
+    this.emit('error', new Error('faux-jax: Cannot call `restore()` when not installed'));
+    return;
+  }
+
+  if (support.xhr) {
+    global.XMLHttpRequest = native.XMLHttpRequest;
+  }
+
+  if (support.xdr) {
+    global.XDomainRequest = native.XDomainRequest;
+  }
+
+  this.removeAllListeners('request');
+  this._installed = false;
+};
+
+FauxJax.prototype.waitFor = function(n, callback) {
+  var fj = this;
+  var fakeRequests = [];
+
+  this.on('request', waitFor);
+
+  function waitFor(fakeRequest) {
+    fakeRequests.push(fakeRequest);
+    if (fakeRequests.length === n) {
+      fj.removeListener('request', waitFor);
+      callback(fakeRequests);
+    }
+  }
+};
+
+FauxJax.prototype._newRequest = function(fakeRequest) {
+  if (this.listeners('request').length === 0) {
+    this.emit('error', new Error('faux-jax: received an unexpected request: ' + fakeRequest.requestURL));
+    return;
+  }
+
+  this.emit('request', fakeRequest);
+};
+
+FauxJax.prototype.support = support;
+
+var fauxJax = new FauxJax();
+
+function FakeXHR() {
+  var x = this;
+  XMLHttpRequestMock.call(this);
+  process.nextTick(function() {
+    fauxJax._newRequest(x);
+  });
+}
+
+inherits(FakeXHR, XMLHttpRequestMock);
+
+function FakeXDR() {
+  var x = this;
+  XDomainRequestMock.call(this);
+  process.nextTick(function() {
+    fauxJax._newRequest(x);
+  });
+}
+
+inherits(FakeXDR, XDomainRequestMock);
+
+module.exports = fauxJax;

--- a/browser.js
+++ b/browser.js
@@ -61,7 +61,7 @@ FauxJax.prototype.waitFor = function(n, callback) {
     fakeRequests.push(fakeRequest);
     if (fakeRequests.length === n) {
       fj.removeListener('request', waitFor);
-      callback(fakeRequests);
+      callback(null, fakeRequests);
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,62 +1,124 @@
+var EventEmitter = require('events').EventEmitter;
 var inherits = require('util').inherits;
 
-var XMLHttpRequestMock = require('./lib/XMLHttpRequest/');
-var XDomainRequestMock = require('./lib/XDomainRequest/');
-var native = require('./lib/native');
-var support = require('./lib/support');
+var forEach = require('lodash').forEach;
+var Mitm = require('mitm');
 
-var fauxJax = module.exports = {};
+function FauxJax() {
+  this._installed = false;
+}
 
-var installed;
+inherits(FauxJax, EventEmitter);
 
-fauxJax.install = function() {
-  if (installed) {
-    throw new Error('Cannot call `fauxJax.install()` twice. Did you forgot to call `fauxJax.restore()`?');
+FauxJax.prototype.install = function() {
+  if (this._installed) {
+    this.emit('error', new Error('faux-jax: Cannot call `install()` twice. Did you forgot to call `restore()`?'));
+    return;
   }
 
-  installed = true;
+  this._installed = true;
 
-  // only modify the writable state of XMLHttpRequest in old ies when installing
-  // it will be done only once
-  require('./lib/make-native-implementations-writable')();
+  this._mitm = Mitm();
+  this._mitm.on('request', this._newRequest.bind(this));
+  this._mitm.on('connect', this._newSocket.bind(this));
+};
 
-  if (support.xhr) {
-    global.XMLHttpRequest = FakeXHR;
+FauxJax.prototype.restore = function() {
+  if (!this._installed) {
+    this.emit('error', new Error('faux-jax: Cannot call `restore()` when not installed'));
+    return;
   }
 
-  if (support.xdr) {
-    global.XDomainRequest = FakeXDR;
+  this._installed = false;
+  this._mitm.disable();
+  this.removeAllListeners('request');
+};
+
+FauxJax.prototype.waitFor = function(n, callback) {
+  var fj = this;
+  var fakeRequests = [];
+
+  this.on('request', waitFor);
+
+  function waitFor(fakeRequest) {
+    fakeRequests.push(fakeRequest);
+    if (fakeRequests.length === n) {
+      fj.removeListener('request', waitFor);
+      callback(fakeRequests);
+    }
   }
 };
 
-fauxJax.restore = function() {
-  installed = false;
-
-  if (support.xhr) {
-    global.XMLHttpRequest = native.XMLHttpRequest;
-  }
-
-  if (support.xdr) {
-    global.XDomainRequest = native.XDomainRequest;
-  }
-
-  fauxJax.requests = [];
+// specific Node.JS implementation, can be used to
+// socket.emit('error') which will then be
+FauxJax.prototype._newSocket = function(socket) {
+  this.emit('socket', socket);
 };
 
-fauxJax.requests = [];
+FauxJax.prototype._newRequest = function(req, res) {
+  if (this.listeners('request').length === 0) {
+    this.emit('error', new Error('faux-jax: received an unexpected request: ' + req.url));
+    return;
+  }
 
-fauxJax.support = support;
+  var fj = this;
+  var chunks = [];
 
-function FakeXHR() {
-  XMLHttpRequestMock.call(this);
-  fauxJax.requests.push(this);
+  var fakeRequest = new FakeRequest({
+    requestMethod: req.method,
+    // cannot detect http from https for now,
+    // https://github.com/moll/node-mitm/issues/10
+    // so we default to http
+    requestURL: 'http://' + req.headers.host + req.url,
+    requestHeaders: req.headers,
+    requestBody: null,
+    res: res
+  });
+
+  req.on('end', function() {
+    if (chunks.length > 0) {
+      fakeRequest.requestBody = Buffer.concat(chunks).toString();
+    }
+
+    fj.emit('request', fakeRequest);
+  });
+
+  req.on('data', function(chunk) {
+    chunks.push(chunk);
+  });
+};
+
+function FakeRequest(opts) {
+  this._res = opts.res;
+  this.requestMethod = opts.requestMethod;
+  this.requestURL = opts.requestURL;
+  this.requestHeaders = opts.requestHeaders;
+  this.requestBody = opts.requestBody;
 }
 
-inherits(FakeXHR, XMLHttpRequestMock);
+FakeRequest.prototype.setResponseHeaders = function(headers) {
+  var fj = this;
+  forEach(headers, function(headerValue, headerName) {
+    fj._res.setHeader(headerName, headerValue);
+  });
+};
 
-function FakeXDR() {
-  XDomainRequestMock.call(this);
-  fauxJax.requests.push(this);
-}
+FakeRequest.prototype.setResponseBody = function(body) {
+  this._res.write(body);
+};
 
-inherits(FakeXDR, XDomainRequestMock);
+FakeRequest.prototype.respond = function(statusCode, headers, body) {
+  if (headers) {
+    this.setResponseHeaders(headers);
+  }
+
+  this._res.statusCode = statusCode;
+
+  if (body !== undefined) {
+    this.setResponseBody(body);
+  }
+
+  this._res.socket.emit('end');
+};
+
+module.exports = new FauxJax();

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ FauxJax.prototype.waitFor = function(n, callback) {
     fakeRequests.push(fakeRequest);
     if (fakeRequests.length === n) {
       fj.removeListener('request', waitFor);
-      callback(fakeRequests);
+      callback(null, fakeRequests);
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Intercept Ajax requests and respond to them. Supports XMLHttpRequest and XDomainRequest. Close to the specs.",
   "main": "index.js",
   "scripts": {
-    "test": "echo 'use either npm run dev or npm run test-ci'",
-    "test-ci": "DEBUG=zuul* zuul --tunnel ngrok test/index.js && npm run lint",
-    "lint": "eslint --quiet .",
-    "dev": "DEBUG=zuul* zuul --local 8080 test/index.js"
+    "dev": "DEBUG=zuul* zuul --local 8080 -- test/browser/index.js",
+    "test": "npm run test-phantom | tap-spec && npm run test-node | tap-spec && npm run lint",
+    "test-phantom": "zuul --phantom -- test/browser/index.js",
+    "test-node": "node test/node/index.js",
+    "test-ci-browser": "DEBUG=zuul* zuul --tunnel ngrok test/browser/index.js",
+    "lint": "eslint --quiet ."
   },
   "keywords": [
     "xhr",
@@ -26,14 +28,19 @@
     "bulkify": "1.1.1",
     "domready": "0.3.0",
     "eslint": "0.16.1",
+    "phantomjs": "1.9.16",
     "sinon": "1.13.0",
+    "tap-spec": "2.2.2",
     "tape": "3.5.0",
     "zuul": "2.1.1",
     "zuul-ngrok": "3.0.0"
   },
   "dependencies": {
     "bowser": "0.7.2",
+    "lodash": "3.6.0",
     "lodash-compat": "3.5.0",
+    "mitm": "1.0.3",
     "writable-window-method": "1.0.3"
-  }
+  },
+  "browser": "browser.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faux-jax",
   "version": "3.0.1",
-  "description": "Intercept Ajax requests and respond to them. Supports XMLHttpRequest and XDomainRequest. Close to the specs.",
+  "description": "Intercept and respond to requests in the browser (XMLHttpRequest, XDomainRequest) and Node.js (http(s) module)",
   "main": "index.js",
   "scripts": {
     "dev": "DEBUG=zuul* zuul --local 8080 -- test/browser/index.js",
@@ -18,7 +18,9 @@
     "ajax",
     "fake",
     "mock",
-    "testing"
+    "testing",
+    "http",
+    "nodejs"
   ],
   "author": "Vincent Voyer <vincent.voyer@algolia.com>",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,10 @@ All requests have the native properties/methods from [the spec](https://xhr.spec
 
 We also added a couple of handy properties/methods for you to ease testing.
 
+## fauxJax.waitFor(nbRequests, cb)
+
+Utility to "wait for n requests". Will call `cb(err, requests)`.
+
 ### request.requestMethod
 
 ### request.requestURL

--- a/test/browser/XDomainRequest/abort.js
+++ b/test/browser/XDomainRequest/abort.js
@@ -1,5 +1,5 @@
 var test = require('tape');
-var XDomainRequest = require('../../lib/XDomainRequest/');
+var XDomainRequest = require('../../../lib/XDomainRequest/');
 
 // https://msdn.microsoft.com/en-us/library/ie/cc288060(v=vs.85).aspx
 test('xdr.abort() cancels the current HTTP request', function(t) {

--- a/test/browser/XDomainRequest/contructor_.js
+++ b/test/browser/XDomainRequest/contructor_.js
@@ -1,5 +1,5 @@
 var test = require('tape');
-var XDomainRequest = require('../../lib/XDomainRequest/');
+var XDomainRequest = require('../../../lib/XDomainRequest/');
 
 // https://msdn.microsoft.com/en-us/library/ie/cc288060(v=vs.85).aspx
 test('XDomainRequest interface', function(t) {

--- a/test/browser/XDomainRequest/open.js
+++ b/test/browser/XDomainRequest/open.js
@@ -1,7 +1,7 @@
 var bind = require('lodash-compat/function/bind');
 var forEach = require('lodash-compat/collection/forEach');
 var test = require('tape');
-var XDomainRequest = require('../../lib/XDomainRequest/');
+var XDomainRequest = require('../../../lib/XDomainRequest/');
 
 test('xdr.open() throws when missing parameters', function(t) {
   t.plan(1);

--- a/test/browser/XDomainRequest/respond.js
+++ b/test/browser/XDomainRequest/respond.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 
-var XDomainRequest = require('../../lib/XDomainRequest/');
+var XDomainRequest = require('../../../lib/XDomainRequest/');
 
 test('xdr.respond() calls setResponseHeaders', function(t) {
   var headers = {'how': 'dy'};

--- a/test/browser/XDomainRequest/send.js
+++ b/test/browser/XDomainRequest/send.js
@@ -1,7 +1,7 @@
 var bind = require('lodash-compat/function/bind');
 var test = require('tape');
 
-var XDomainRequest = require('../../lib/XDomainRequest/');
+var XDomainRequest = require('../../../lib/XDomainRequest/');
 
 test('xdr.send() throws when body is not a string', function(t) {
   var xdr = new XDomainRequest();

--- a/test/browser/XDomainRequest/setResponseBody.js
+++ b/test/browser/XDomainRequest/setResponseBody.js
@@ -1,8 +1,8 @@
 var bind = require('lodash-compat/function/bind');
 var test = require('tape');
 
-var support = require('../../lib/support');
-var XDomainRequest = require('../../lib/XDomainRequest/');
+var support = require('../../../lib/support');
+var XDomainRequest = require('../../../lib/XDomainRequest/');
 
 test('xdr.setResponseBody() throws when no body', function(t) {
   var xdr = new XDomainRequest();

--- a/test/browser/XDomainRequest/setResponseHeaders.js
+++ b/test/browser/XDomainRequest/setResponseHeaders.js
@@ -1,7 +1,7 @@
 var bind = require('lodash-compat/function/bind');
 var test = require('tape');
 
-var XDomainRequest = require('../../lib/XDomainRequest/');
+var XDomainRequest = require('../../../lib/XDomainRequest/');
 
 test('xdr.setResponseHeaders() throws when request not sent', function(t) {
   var xdr = new XDomainRequest();

--- a/test/browser/XDomainRequest/timeout.js
+++ b/test/browser/XDomainRequest/timeout.js
@@ -1,7 +1,7 @@
 var test = require('tape');
 
-var support = require('../../lib/support');
-var XDomainRequest = require('../../lib/XDomainRequest/');
+var support = require('../../../lib/support');
+var XDomainRequest = require('../../../lib/XDomainRequest/');
 
 test('timeout is initialized at -1', function(t) {
   var xdr = new XDomainRequest();

--- a/test/browser/XMLHttpRequest/abort.js
+++ b/test/browser/XMLHttpRequest/abort.js
@@ -1,8 +1,8 @@
 var forEach = require('lodash-compat/collection/forEach');
 var test = require('tape');
 
-var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
-var support = require('../../lib/support');
+var XMLHttpRequest = require('../../../lib/XMLHttpRequest/');
+var support = require('../../../lib/support');
 
 if (support.xhr.response) {
   test('xhr.abort() sets response to error when state > UNSENT and send() flag is true', function(t) {

--- a/test/browser/XMLHttpRequest/constructor_.js
+++ b/test/browser/XMLHttpRequest/constructor_.js
@@ -3,8 +3,8 @@
 
 var test = require('tape');
 
-var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
-var support = require('../../lib/support');
+var XMLHttpRequest = require('../../../lib/XMLHttpRequest/');
+var support = require('../../../lib/support');
 
 // https://xhr.spec.whatwg.org/#interface-xmlhttprequest
 test('XMLHttpRequest interface', function(t) {

--- a/test/browser/XMLHttpRequest/getAllResponseHeaders.js
+++ b/test/browser/XMLHttpRequest/getAllResponseHeaders.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 
-var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
+var XMLHttpRequest = require('../../../lib/XMLHttpRequest/');
 
 test('xhr.getAllResponseHeaders() sends empty string when no headers', function(t) {
   var xhr = new XMLHttpRequest();

--- a/test/browser/XMLHttpRequest/open.js
+++ b/test/browser/XMLHttpRequest/open.js
@@ -2,7 +2,7 @@ var bind = require('lodash-compat/function/bind');
 var forEach = require('lodash-compat/collection/forEach');
 var test = require('tape');
 
-var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
+var XMLHttpRequest = require('../../../lib/XMLHttpRequest/');
 
 test('xhr.open() throws when method not a string', function(t) {
   var xhr = new XMLHttpRequest();

--- a/test/browser/XMLHttpRequest/respond.js
+++ b/test/browser/XMLHttpRequest/respond.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 
-var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
+var XMLHttpRequest = require('../../../lib/XMLHttpRequest/');
 
 test('xhr.respond() sets status', function(t) {
   var xhr = new XMLHttpRequest();

--- a/test/browser/XMLHttpRequest/send.js
+++ b/test/browser/XMLHttpRequest/send.js
@@ -2,8 +2,8 @@ var bind = require('lodash-compat/function/bind');
 var forEach = require('lodash-compat/collection/forEach');
 var test = require('tape');
 
-var support = require('../../lib/support');
-var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
+var support = require('../../../lib/support');
+var XMLHttpRequest = require('../../../lib/XMLHttpRequest/');
 
 test('xhr.send() throws when state is not OPENED', function(t) {
   var xhr = new XMLHttpRequest();

--- a/test/browser/XMLHttpRequest/setRequestHeader.js
+++ b/test/browser/XMLHttpRequest/setRequestHeader.js
@@ -1,7 +1,7 @@
 var bind = require('lodash-compat/function/bind');
 var test = require('tape');
 
-var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
+var XMLHttpRequest = require('../../../lib/XMLHttpRequest/');
 
 test('xhr.setRequestHeader() throws when state is not OPENED', function(t) {
   var xhr = new XMLHttpRequest();

--- a/test/browser/XMLHttpRequest/setResponseBody.js
+++ b/test/browser/XMLHttpRequest/setResponseBody.js
@@ -1,8 +1,8 @@
 var bind = require('lodash-compat/function/bind');
 var test = require('tape');
 
-var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
-var support = require('../../lib/support');
+var XMLHttpRequest = require('../../../lib/XMLHttpRequest/');
+var support = require('../../../lib/support');
 
 test('xhr.setResponseBody() throws when body is not a String', function(t) {
   var xhr = new XMLHttpRequest();

--- a/test/browser/XMLHttpRequest/setResponseHeaders.js
+++ b/test/browser/XMLHttpRequest/setResponseHeaders.js
@@ -1,7 +1,7 @@
 var bind = require('lodash-compat/function/bind');
 var test = require('tape');
 
-var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
+var XMLHttpRequest = require('../../../lib/XMLHttpRequest/');
 
 test('xhr.setResponseHeaders() throws when no headers given', function(t) {
   var xhr = new XMLHttpRequest();

--- a/test/browser/XMLHttpRequest/timeout.js
+++ b/test/browser/XMLHttpRequest/timeout.js
@@ -1,7 +1,7 @@
 var test = require('tape');
 
-var XMLHttpRequest = require('../../lib/XMLHttpRequest/');
-var support = require('../../lib/support');
+var XMLHttpRequest = require('../../../lib/XMLHttpRequest/');
+var support = require('../../../lib/support');
 
 if (support.xhr.timeout) {
   test('xhr.timeout is initialized at 0', function(t) {

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -8,10 +8,7 @@ test('fauxJax intercepts http requests', function(t) {
 
   fauxJax.once('request', function(req) {
     t.equal(req.requestURL, 'http://www.google.com/');
-    t.deepEqual(req.requestHeaders, {
-      connection: 'keep-alive',
-      host: 'www.google.com'
-    });
+    t.ok(req.requestHeaders);
     t.equal(req.requestBody, null);
     t.equal(req.requestMethod, 'GET');
     req.respond(200, {

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -1,0 +1,35 @@
+var test = require('tape');
+
+test('fauxJax intercepts http requests', function(t) {
+  var fauxJax = require('../../');
+  var http = require('http');
+
+  fauxJax.install();
+
+  fauxJax.once('request', function(req) {
+    t.equal(req.requestURL, 'http://www.google.com/');
+    t.deepEqual(req.requestHeaders, {
+      connection: 'keep-alive',
+      host: 'www.google.com'
+    });
+    t.equal(req.requestBody, null);
+    t.equal(req.requestMethod, 'GET');
+    req.respond(200, {
+      XLOL: 'test'
+    }, 'Hello! HTTP!');
+  });
+
+  http.request('http://www.google.com', function(res) {
+    var chunks = [];
+    res.on('data', function(chunk) {
+      chunks.push(chunk);
+    });
+
+    res.on('end', function() {
+      t.equal(res.statusCode, 200);
+      t.equal(res.headers.xlol, 'test');
+      t.equal(Buffer.concat(chunks).toString(), 'Hello! HTTP!');
+      t.end();
+    });
+  }).end();
+});


### PR DESCRIPTION
Using [moll/node-mitm](https://github.com/moll/node-mitm) I was able to make faux-jax intercept Node.js http/https module using the same interface.

It means faux-jax now works both on the browser and the server.

The big change is that intercepting requests is now asynchronous:

```js
var fauxJax = require('faux-jax');

fauxJax.on('request', function(request) {
  // request.respond..
});
```