### PR TITLE
Sync XHR support

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -80,23 +80,35 @@ FauxJax.prototype.support = support;
 var fauxJax = new FauxJax();
 
 function FakeXHR() {
-  var x = this;
   XMLHttpRequestMock.call(this);
-  process.nextTick(function() {
-    fauxJax._newRequest(x);
-  });
 }
 
 inherits(FakeXHR, XMLHttpRequestMock);
 
+FakeXHR.prototype.send = function() {
+  var req = this;
+  XMLHttpRequestMock.prototype.send.apply(req, arguments);
+  if (req.async) {
+    setTimeout(function() {
+      fauxJax._newRequest(req);
+    });
+  } else {
+    fauxJax._newRequest(req);
+  }
+};
+
 function FakeXDR() {
-  var x = this;
   XDomainRequestMock.call(this);
-  process.nextTick(function() {
-    fauxJax._newRequest(x);
-  });
 }
 
 inherits(FakeXDR, XDomainRequestMock);
+
+FakeXDR.prototype.send = function() {
+  var req = this;
+  XDomainRequestMock.prototype.send.apply(req, arguments);
+  setTimeout(function() {
+    fauxJax._newRequest(req);
+  });
+};
 
 module.exports = fauxJax;

--- a/test/browser/XMLHttpRequest/sync.js
+++ b/test/browser/XMLHttpRequest/sync.js
@@ -1,0 +1,18 @@
+var test = require('tape');
+var fauxJax = require('../../../browser.js');
+
+test('xhr.respond() works for sync xhr', function(t) {
+  fauxJax.install();
+
+  fauxJax.once('request', function(req) {
+    req.respond(200, {}, 'WOSYNC!');
+  });
+
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', '/fo1pf1', false);
+  xhr.send();
+  t.equal(xhr.responseText, 'WOSYNC!', 'xhr.respond() call worked synchronously');
+
+  fauxJax.restore();
+  t.end();
+});


### PR DESCRIPTION
This change allows synchronous xhr results to be submitted synchronously if `request.respond` is called in the same frame as the `request` event was emitted.

conversely, this also guarantees async xhrs are guaranteed to be async even if `request.respond` is called in the same frame as the `request` event was emitted.

Added a test to ensure this behavior. All tests pass.