### PR TITLE
Remove "restore" listener on response-end, otherwise it gets leaked

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,6 +166,7 @@ FakeRequest.prototype.setResponseBody = function(body, cb) {
 
 FakeRequest.prototype.respond = function(statusCode, headers, body) {
   var res = this._res;
+  var fj = this._fj;
 
   if (this._gzip === true) {
     this.setResponseHeaders({'content-encoding': 'gzip'});
@@ -186,6 +187,7 @@ FakeRequest.prototype.respond = function(statusCode, headers, body) {
 
   function end() {
     res.end();
+    fj.emit('response-end');
     try {
       res.socket.emit('end');
     } catch (e) {
@@ -196,7 +198,9 @@ FakeRequest.prototype.respond = function(statusCode, headers, body) {
 
 FakeRequest.prototype._setTimeout = function(ms) {
   this._timeout = setTimeout(this._timedout.bind(this), ms);
-  this._fj.once('restore', this._clearTimeout.bind(this));
+  this._timeoutListener = this._clearTimeout.bind(this);
+  this._fj.once('restore', this._timeoutListener);
+  this._fj.once('response-end', this._timeoutListener);
 };
 
 FakeRequest.prototype._timedout = function() {
@@ -205,6 +209,8 @@ FakeRequest.prototype._timedout = function() {
 
 FakeRequest.prototype._clearTimeout = function() {
   clearTimeout(this._timeout);
+  this._fj.removeListener('restore', this._timeoutListener);
+  this._fj.removeListener('response-end', this._timeoutListener);
 };
 
 module.exports = new FauxJax();

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -32,6 +32,27 @@ test('fauxJax intercepts http requests', function(t) {
   }).end();
 });
 
+test('does not leak listeners', function(t) {
+  var fauxJax = require('../../');
+  var http = require('http');
+
+  fauxJax.install();
+
+  fauxJax.once('request', function(req) {
+    t.equal(fauxJax.listeners('restore').length, 1);
+    req.respond(200, {}, '.');
+  });
+
+  http.request('http://www.google.com', function(res) {
+    res.on('data', function() { });
+    res.on('end', function() {
+      t.equal(fauxJax.listeners('restore').length, 0);
+      fauxJax.restore();
+      t.end();
+    });
+  }).end();
+});
+
 test('fauxJax intercepts https requests', function(t) {
   var fauxJax = require('../../');
   var https = require('https');


### PR DESCRIPTION
I like HTTP mocking, and I like faux-jax... but naturally, as a developer - I get fitzy, so I made https://github.com/ponelat/xmock.
While testing it, I came across a `possible EventEmitter memory leak detected... Use emitter.setMaxListeners() to increase limit` warning, it peeved me slightly, so I tried to fix it.
This PR is that fix.