### PR TITLE
Update to latest mitm to fix "normalizeConnectArgs is not a function"

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var inherits = require('util').inherits;
 var zlib = require('zlib');
 
 var forEach = require('lodash').forEach;
-var Mitm = require('mitm-algolia');
+var Mitm = require('mitm');
 
 function FauxJax() {
   this._installed = false;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bowser": "^1.4.5",
     "lodash": "^4.16.3",
     "lodash-compat": "^3.10.2",
-    "mitm-algolia": "^1.3.0-algolia-patch.0",
+    "mitm": "^1.3.2",
     "writable-window-method": "1.0.3"
   },
   "browser": "browser.js"


### PR DESCRIPTION
Hi, thanks for this awesome library.

When running with node 7/7.1 it is raising `TypeError: normalizeConnectArgs is not a function`, I've seen issue #24 and it is exactly the same case. The library is working well with the latest version, all tests are green.

This is a small PR which only updates `mitm`.
Thanks.